### PR TITLE
filter seize options by active expansions

### DIFF
--- a/common/innovation/innovation.js
+++ b/common/innovation/innovation.js
@@ -1497,11 +1497,22 @@ Innovation.prototype._checkCanSeizeRelic = function(card) {
 }
 
 Innovation.prototype.aSeizeRelic = function(player, card) {
-  const choice = this.aChoose(player, [
-    'to my achievements',
-    'to my hand',
-    'do not seize',
-  ], { title: `How would you like to seize ${card.name}` })[0]
+  console.log(card, this.getExpansionList(), this.getExpansionList().includes(card.relicExpansion))
+
+  const relicSeizeOptions =
+    this.getExpansionList().includes(card.relicExpansion) ?
+      [
+        'to my achievements',
+        'to my hand',
+        'do not seize',
+      ] : [
+        'to my achievements',
+        'do not seize',
+      ]
+
+  const choice = this.aChoose(player, relicSeizeOptions, {
+    title: `How would you like to seize ${card.name}`
+  })[0]
 
   if (choice === 'to my achievements') {
     this.mMoveCardTo(card, this.getZoneByPlayer(player, 'achievements'), { player })

--- a/common/innovation/innovation.js
+++ b/common/innovation/innovation.js
@@ -1497,8 +1497,6 @@ Innovation.prototype._checkCanSeizeRelic = function(card) {
 }
 
 Innovation.prototype.aSeizeRelic = function(player, card) {
-  console.log(card, this.getExpansionList(), this.getExpansionList().includes(card.relicExpansion))
-
   const relicSeizeOptions =
     this.getExpansionList().includes(card.relicExpansion) ?
       [

--- a/common/innovation/res/arti/achievements/ChingShih.js
+++ b/common/innovation/res/arti/achievements/ChingShih.js
@@ -19,6 +19,7 @@ function Card() {
     `If you would score a non-figure, instead transfer a card of the same value from an opponent's score pile to yours.`,
   ]
   this.dogma = []
+  this.relicExpansion = 'figs'
 
   this.dogmaImpl = []
   this.echoImpl = []

--- a/common/innovation/res/arti/achievements/ComplexNumbers.js
+++ b/common/innovation/res/arti/achievements/ComplexNumbers.js
@@ -17,6 +17,7 @@ function Card() {
   this.dogma = [
     `You may reveal a card from your hand having exactly the same icons, in type and number, as a top card on your board. If you do, claim an achievement of matching value, ignoring eligibility.`
   ]
+  this.relicExpansion = 'base'
 
   this.dogmaImpl = [
     (game, player) => {

--- a/common/innovation/res/arti/achievements/NewtonWickinsTelescope.js
+++ b/common/innovation/res/arti/achievements/NewtonWickinsTelescope.js
@@ -17,6 +17,7 @@ function Card() {
   this.dogma = [
     `You may return any number of cards from your score pile. If you do, draw and meld a card of value equal to the number of cards returned. If the melded card has a {i}, return it.`
   ]
+  this.relicExpansion = 'arti'
 
   this.dogmaImpl = [
     (game, player) => {

--- a/common/innovation/res/arti/achievements/SafetyPin.js
+++ b/common/innovation/res/arti/achievements/SafetyPin.js
@@ -17,6 +17,7 @@ function Card() {
   this.dogma = [
     `I demand you return all cards of value higher than 6 from your hand! Draw a {6}!`
   ]
+  this.relicExpansion = 'echo'
 
   this.dogmaImpl = [
     (game, player) => {

--- a/common/innovation/res/arti/achievements/Timbuktu.js
+++ b/common/innovation/res/arti/achievements/Timbuktu.js
@@ -16,6 +16,7 @@ function Card() {
   this.echo = ``
   this.karma = []
   this.dogma = []
+  this.relicExpansion = 'city'
 
   this.dogmaImpl = []
   this.echoImpl = []


### PR DESCRIPTION
according to the rules, if the expansion that a relic "belongs" to is not in play, you may not seize that relic to your hand (only achievements, or not at all). this commit introduces a `relicExpansion` field on the card, and checks that against the set of active expansions before the seize prompt is displayed so that the rules are properly enforced.