### PR TITLE
flag achievement logic should pass for ties

### DIFF
--- a/common/innovation/innovation.js
+++ b/common/innovation/innovation.js
@@ -1909,7 +1909,7 @@ Innovation.prototype.getAchievementsByPlayer = function(player) {
     }
   }
 
-  const flags = this
+  const flagsTemp = this
     .utilColors()
     .flatMap(color => this.getCardsByZone(player, color))
     .map(card => {
@@ -1927,7 +1927,7 @@ Innovation.prototype.getAchievementsByPlayer = function(player) {
         .getPlayerAll()
         .filter(other => other !== player)
         .map(other => this.getVisibleCardsByZone(other, x.card.color))
-      return otherCounts.every(count => count < myCount)
+      return otherCounts.every(count => count <= myCount)
     })
     .forEach(x => {
       for (let i = 0; i < x.count; i++) {

--- a/common/innovation/innovation.test.js
+++ b/common/innovation/innovation.test.js
@@ -219,7 +219,7 @@ describe('Innovation', () => {
     })
   })
 
-  describe('cities biscuits', () => {
+  describe.only('cities biscuits', () => {
     test('plus icon', () => {
       const game = t.fixtureFirstPlayer({ expansions: ['base', 'city'] })
       t.setBoard(game, {
@@ -246,23 +246,6 @@ describe('Innovation', () => {
       })
     })
 
-    test('flag but not most', () => {
-      const game = t.fixtureFirstPlayer({ expansions: ['base', 'city'] })
-      t.setBoard(game, {
-        dennis: {
-          purple: ['Tokyo'],
-        },
-        micah: {
-          purple: ['Enterprise'],
-        },
-      })
-
-      const request1 = game.run()
-
-      const achievements = game.getAchievementsByPlayer(t.dennis(game))
-      expect(achievements.total).toBe(0)
-    })
-
     test('flag and most', () => {
       const game = t.fixtureFirstPlayer({ expansions: ['base', 'city'] })
       t.setBoard(game, {
@@ -281,6 +264,41 @@ describe('Innovation', () => {
 
       const achievements = game.getAchievementsByPlayer(t.dennis(game))
       expect(achievements.total).toBe(1)
+    })
+
+    test.only('flag and equal', () => {
+      const game = t.fixtureFirstPlayer({ expansions: ['base', 'city'] })
+      t.setBoard(game, {
+        dennis: {
+          purple: ['Tokyo'],
+        },
+        micah: {
+          purple: ['Enterprise'],
+        },
+      })
+
+      const request1 = game.run()
+
+      const achievements = game.getAchievementsByPlayer(t.dennis(game))
+      expect(achievements.total).toBe(1)
+    })
+
+    test('flag and not most', () => {
+      const game = t.fixtureFirstPlayer({ expansions: ['base', 'city'] })
+      t.setBoard(game, {
+        dennis: {
+          purple: ['Tokyo'],
+        },
+        micah: {
+          purple: ['Enterprise', 'Kaleidoscope'],
+          splay: 'left'
+        },
+      })
+
+      const request1 = game.run()
+
+      const achievements = game.getAchievementsByPlayer(t.dennis(game))
+      expect(achievements.total).toBe(0)
     })
 
     test('flag and most, but not splayed, so not visible', () => {


### PR DESCRIPTION
rulebook says:
> Flag: While a flag is visible, it counts as an achievement if
no opponent has more visible cards of the flag’s color
than you do.

which suggests that ties should still grant the virtual achievement.

<img width="472" alt="image" src="https://github.com/dennishorte/battlestar/assets/1939552/00a04dfa-27d3-4340-beab-0c8d12d717d0">
